### PR TITLE
Fix Redundant Variable Declaration in Arithmetic Error Handling

### DIFF
--- a/contracts/lib/forge-std/README.md
+++ b/contracts/lib/forge-std/README.md
@@ -31,16 +31,16 @@ contract TestContract is Test {
     }
 
     function testExpectArithmetic() public {
-    vm.expectRevert(stdError.arithmeticError);
-    test.arithmeticError(10);
-}
+        vm.expectRevert(stdError.arithmeticError);
+        test.arithmeticError(10);
+    }
 }
 
 contract ErrorsTest {
     function arithmeticError(uint256 a) public {
         a = a - 100;
     }
-} 
+}
 ```
 
 ### stdStorage

--- a/contracts/lib/forge-std/README.md
+++ b/contracts/lib/forge-std/README.md
@@ -31,16 +31,16 @@ contract TestContract is Test {
     }
 
     function testExpectArithmetic() public {
-        vm.expectRevert(stdError.arithmeticError);
-        test.arithmeticError(10);
-    }
+    vm.expectRevert(stdError.arithmeticError);
+    test.arithmeticError(10);
+}
 }
 
 contract ErrorsTest {
     function arithmeticError(uint256 a) public {
-        uint256 a = a - 100;
+        a = a - 100;
     }
-}
+} 
 ```
 
 ### stdStorage


### PR DESCRIPTION
Before:
-        uint256 a = a - 100;
After:
+        a = a - 100;

In the original version of the code, a new variable a is declared, which is a mistake. The variable a has already been passed as a parameter to the function, and redeclaring it inside the function creates a new variable with the same name, leading to a conflict